### PR TITLE
Add watched boolean field and DB column to Film

### DIFF
--- a/app/src/main/java/com/victormordur/gihbli/app/data/model/Film.kt
+++ b/app/src/main/java/com/victormordur/gihbli/app/data/model/Film.kt
@@ -2,6 +2,7 @@ package com.victormordur.gihbli.app.data.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 data class Film(
@@ -17,4 +18,6 @@ data class Film(
     val director: String,
     @SerialName("image")
     val imageURL: String,
+    @Transient
+    val watched: Boolean = false
 )

--- a/app/src/main/sqldelight/gihbli/Film.sq
+++ b/app/src/main/sqldelight/gihbli/Film.sq
@@ -4,7 +4,8 @@ CREATE TABLE Film (
     description TEXT NOT NULL,
     releaseDate TEXT NOT NULL,
     director TEXT NOT NULL,
-    imageURL TEXT NOT NULL
+    imageURL TEXT NOT NULL,
+    watched INTEGER AS Boolean NOT NULL
 );
 
 selectAll:
@@ -14,7 +15,10 @@ selectById:
 SELECT * FROM Film WHERE id = ?;
 
 insert:
-INSERT OR REPLACE INTO Film(id,title,description,releaseDate,director,imageURL) VALUES (?,?,?,?,?,?);
+INSERT OR REPLACE INTO Film(id,title,description,releaseDate,director,imageURL,watched) VALUES (?,?,?,?,?,?,?);
+
+updateWatched:
+UPDATE Film SET watched = ? WHERE id = ?;
 
 delete:
 DELETE FROM Film WHERE id = ?;

--- a/app/src/test/java/com/victormordur/gihbli/app/db/GihbliDbTest.kt
+++ b/app/src/test/java/com/victormordur/gihbli/app/db/GihbliDbTest.kt
@@ -63,6 +63,20 @@ class GihbliDbTest {
         Assert.assertTrue(updatedFilms.isEmpty())
     }
 
+    @Test
+    fun testInsertAndUpdateWatched() {
+        val queries = Database(driver).filmQueries
+        queries.insertDefaultRows(2)
+        val films = queries.selectAll().executeAsList()
+        Assert.assertEquals(films.size, 2)
+        Assert.assertTrue(films.all { !it.watched })
+        queries.updateWatched(true, "id2")
+        val film1 = queries.selectById("id1").executeAsOne()
+        val film2 = queries.selectById("id2").executeAsOne()
+        Assert.assertFalse(film1.watched)
+        Assert.assertTrue(film2.watched)
+    }
+
     private fun FilmQueries.insertDefaultRows(rows: Int) {
         if (rows > 1) {
             for (i in 1.until(rows + 1)) {
@@ -72,7 +86,8 @@ class GihbliDbTest {
                     "description$i",
                     "date$i",
                     "director$i",
-                    "imageURL$i"
+                    "imageURL$i",
+                    false
                 )
             }
         } else {

--- a/app/src/test/java/com/victormordur/gihbli/app/model/SerializationTest.kt
+++ b/app/src/test/java/com/victormordur/gihbli/app/model/SerializationTest.kt
@@ -1,0 +1,25 @@
+package com.victormordur.gihbli.app.model
+
+import com.victormordur.gihbli.app.data.model.Film
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert
+import org.junit.Test
+
+class SerializationTest {
+
+    companion object {
+        val jsonParser = Json { encodeDefaults = true }
+    }
+
+    @Test
+    fun testWatchFieldNotSerialized() {
+        val watchedFilm =
+            Film("id", "title", "description", "releaseDate", "director", "imageURL", true)
+        val json = jsonParser.encodeToString(watchedFilm)
+        val deserializedFilm = jsonParser.decodeFromString(Film.serializer(), json)
+        Assert.assertTrue(json.contains("release_date"))
+        Assert.assertFalse(json.contains("watched"))
+        Assert.assertFalse(deserializedFilm.watched)
+    }
+}


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
An additional `watch` field has been added to the Film model and an equivalent column to the Film table in the DB.

## 📄 Motivation and Context
The information whether a Film has been watched is required and needs to be persisted locally in the app.

## 🧪 How Has This Been Tested?
- Added test to validate the query to update the column.
- Added test to validate that the new field is not taken into account for the serialization/deserialization of the field.

## 📷 Screenshots (if appropriate)
NA

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.